### PR TITLE
fix: v5.2.2 tar.gz download href

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@
           <div class="d-inline-flex list-group mb-2">
             <a href="https://github.com/RDARegistry/RDA-Vocabularies/archive/v5.2.2.zip"
               class="list-group-item list-group-item-action px-2 py-1">v5.2.2 (zip)</a>
-            <a href="https://github.com/RDARegistry/RDA-Vocabularies/archive/v5.2.2.tar.g"
+            <a href="https://github.com/RDARegistry/RDA-Vocabularies/archive/v5.2.2.tar.gz"
               class="list-group-item list-group-item-action px-2 py-1">v5.2.2 (tar.gz)</a>
           </div>
           <h3>Contacts</h3>


### PR DESCRIPTION
missing the z on the end of the URL